### PR TITLE
Set minimal running time for serf-join in supervisor config

### DIFF
--- a/supervisord-serf.conf
+++ b/supervisord-serf.conf
@@ -7,3 +7,4 @@ autorestart=true
 [program:serf-join]
 command=/serf-join.sh
 autorestart=false
+startsecs=0

--- a/supervisord-serf.conf
+++ b/supervisord-serf.conf
@@ -6,5 +6,4 @@ autorestart=true
 
 [program:serf-join]
 command=/serf-join.sh
-autorestart=false
 startsecs=0


### PR DESCRIPTION
Due to an issue in supervisord (https://github.com/Supervisor/supervisor/issues/212), the following behavior can be observed when starting the container:

> mysql_1 | 2014-08-04 13:13:55,745 INFO spawned: 'serf' with pid 400
> mysql_1 | 2014-08-04 13:13:55,755 INFO spawned: 'serf-join' with pid 401
> mysql_1 | 2014-08-04 13:13:55,759 INFO spawned: 'mysqld' with pid 402
> mysql_1 | 2014-08-04 13:13:55,819 INFO exited: serf-join (exit status 0; not expected)
> mysql_1 | 2014-08-04 13:13:56,820 INFO success: serf entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
> mysql_1 | 2014-08-04 13:13:56,830 INFO spawned: 'serf-join' with pid 788
> mysql_1 | 2014-08-04 13:13:56,834 INFO success: mysqld entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
> mysql_1 | 2014-08-04 13:13:56,886 INFO exited: serf-join (exit status 0; not expected)
> mysql_1 | 2014-08-04 13:13:58,894 INFO spawned: 'serf-join' with pid 795
> mysql_1 | 2014-08-04 13:13:58,956 INFO exited: serf-join (exit status 0; not expected)
> mysql_1 | 2014-08-04 13:14:01,972 INFO spawned: 'serf-join' with pid 801
> mysql_1 | 2014-08-04 13:14:02,030 INFO exited: serf-join (exit status 0; not expected)
> mysql_1 | 2014-08-04 13:14:03,032 INFO gave up: serf-join entered FATAL state, too many start retries too quickly

"startsecs=0" needs to be added to the corresponding supervisord config file.
